### PR TITLE
bug#39

### DIFF
--- a/catlas/src/component/request.js
+++ b/catlas/src/component/request.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+export const SERVER_CLOSED = 'catlas/SERVER_CLOSED';
+
 export const createInstance = (token = undefined) => {
     const base = 'http://127.0.0.1:8000/api/';
     const timeout = 1000;

--- a/catlas/src/component/request.js
+++ b/catlas/src/component/request.js
@@ -1,7 +1,5 @@
 import axios from 'axios';
 
-export const SERVER_CLOSED = 'catlas/SERVER_CLOSED';
-
 export const createInstance = (token = undefined) => {
     const base = 'http://127.0.0.1:8000/api/';
     const timeout = 1000;

--- a/catlas/src/redux/modules/auth.js
+++ b/catlas/src/redux/modules/auth.js
@@ -2,8 +2,6 @@ import { createInstance } from "../../component/request";
 
 // Ducks pattern
 
-// Implememt when error happened
-
 const LOGIN = "catlas/auth/LOGIN";
 const LOGIN_SUCCEEDED = "catlas/auth/LOGIN_SUCCESS";
 const LOGIN_FAILED = "catlas/auth/LOGIN_FAILED";
@@ -15,10 +13,9 @@ const LOGOUT_FAILED = "catlas/auth/LOGOUT_FAILED";
 const initialState = {
     loading: false,
     isLoggedIn: false,
-    token: "",
-    user: {},
-    error: false,
-    errorCode: ""
+    token: '',
+    user: undefined,
+    errorCode: ''
 };
 
 export default function reducer(state = initialState, action) {
@@ -27,7 +24,6 @@ export default function reducer(state = initialState, action) {
             return {
                 ...state,
                 loading: true,
-                error: false,
                 errorCode: ''
             };
         case LOGIN_SUCCEEDED:
@@ -42,27 +38,27 @@ export default function reducer(state = initialState, action) {
             return {
                 ...state,
                 loading: false,
-                error: true,
                 errorCode: action.code
             };
         case LOGOUT:
             return {
                 ...state,
                 loading: true,
-                error: false
+                errorCode: ''
             };
         case LOGOUT_SUCCEEDED:
             return {
                 ...state,
                 loading: false,
                 isLoggedIn: false,
-                token: ""
+                user: undefined,
+                token: ''
             };
         case LOGOUT_FAILED:
             return {
                 ...state,
                 loading: false,
-                error: true
+                errorCode: action.code
             };
         default:
             return state;
@@ -97,14 +93,15 @@ const loginSuccess = data => {
 }
 
 const loginFail = error => {
-    let code = '';
-
-    if (error.code === 'ECONNABORTED') code = error.code; // axios request timeout
-    else code = error.response.status;
+    let errorCode = '';
+    
+    // axios request timeout
+    if (error.code === 'ECONNABORTED') errorCode = error.code
+    else errorCode = error.response.status;
 
     return {
         type: LOGIN_FAILED,
-        code: code
+        code: errorCode
     }
 }
 
@@ -137,9 +134,14 @@ const logoutSuccess = () => {
 }
 
 const logoutFail = error => {
-    console.log(error);
+    let errorCode = '';
+    
+    // axios request timeout
+    if (error.code === 'ECONNABORTED') errorCode = error.code
+    else errorCode = error.response.status;
 
     return {
-        type: LOGOUT_FAILED
+        type: LOGOUT_FAILED,
+        code: errorCode
     }
 }

--- a/catlas/src/redux/modules/register.js
+++ b/catlas/src/redux/modules/register.js
@@ -7,7 +7,8 @@ const REGISTER_SUCCEEDED = "catlas/register/REGISTER_SUCCEEDED";
 const REGISTER_FAILED = "catlas/register/REGISTER_FAILED";
 
 const initialState = {
-    loading: false
+    loading: false,
+    errorCode: ''
 };
 
 export default function reducer(state = initialState, action) {
@@ -15,7 +16,8 @@ export default function reducer(state = initialState, action) {
         case REGISTER:
             return {
                 ...state,
-                loading: true
+                loading: true,
+                errorCode: ''
             };
         case REGISTER_SUCCEEDED:
             return {
@@ -25,7 +27,8 @@ export default function reducer(state = initialState, action) {
         case REGISTER_FAILED:
             return {
                 ...state,
-                loading: false
+                loading: false,
+                errorCode: action.code
             };
         default:
             return state;
@@ -58,9 +61,14 @@ const registerSuccess = () => {
 }
 
 const registerFail = error => {
-    console.log(error);
+    let errorCode = '';
+    
+    // axios request timeout
+    if (error.code === 'ECONNABORTED') errorCode = error.code
+    else errorCode = error.response.status;
 
     return {
-        type: REGISTER_FAILED
+        type: REGISTER_FAILED,
+        code: errorCode
     }
 }


### PR DESCRIPTION
## 작업사항
1. 이전의 코드에서는 `useSelector`로 가져오는 `errorCode`의 갱신이 원하는 때에 이루어지지 않아, 갱신되기 이전의 값에 따라 처리가 진행됨. 이 처리를 `useEffect`로 이동하여 `errorCode`가 갱신된 이후 페이지가 처리되도록 수정
2. `errorCode`에 따라 에러 메시지를 반환하는 함수 작성
3. `Redux Store`에 `user` 값이 존재할 경우 `/auth` 관련 페이지에 접근하면 메인 페이지로 리다이렉트되도록 수정